### PR TITLE
EQ-01: Implemented kafka

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -72,14 +72,18 @@
 			<version>3.4.0</version>
 		</dependency>
 		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-test</artifactId>
-			<scope>test</scope>
+			<groupId>org.springframework.kafka</groupId>
+			<artifactId>spring-kafka</artifactId>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.kafka</groupId>
-			<artifactId>spring-kafka</artifactId>
-			<version>3.3.0</version>
+			<artifactId>spring-kafka-test</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>com.h2database</groupId>
+			<artifactId>h2</artifactId>
+			<scope>test</scope>
 		</dependency>
 	</dependencies>
 

--- a/src/main/java/com/sharok/esquela/config/KafkaTopicConfig.java
+++ b/src/main/java/com/sharok/esquela/config/KafkaTopicConfig.java
@@ -1,15 +1,21 @@
 package com.sharok.esquela.config;
 
 import org.apache.kafka.clients.admin.NewTopic;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.kafka.config.TopicBuilder;
 
 @Configuration
 public class KafkaTopicConfig {
+    private final String student;
+
+    public KafkaTopicConfig(@Value("${spring.kafka.topic.student}") String student) {
+        this.student = student;
+    }
 
     @Bean
     public NewTopic studentTopic() {
-        return TopicBuilder.name("student-events").partitions(1).replicas(1).build();
+        return TopicBuilder.name(student).partitions(1).replicas(1).build();
     }
 }

--- a/src/main/java/com/sharok/esquela/contract/StudentMessage.java
+++ b/src/main/java/com/sharok/esquela/contract/StudentMessage.java
@@ -1,0 +1,20 @@
+package com.sharok.esquela.contract;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
+public class StudentMessage {
+    private String message;
+    private Long id;
+
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd,HH-mm")
+    private LocalDateTime uploadDate;
+}

--- a/src/main/java/com/sharok/esquela/contract/response/StudentResponse.java
+++ b/src/main/java/com/sharok/esquela/contract/response/StudentResponse.java
@@ -1,5 +1,6 @@
 package com.sharok.esquela.contract.response;
 
+import java.time.LocalDateTime;
 import lombok.*;
 
 @NoArgsConstructor
@@ -15,4 +16,5 @@ public class StudentResponse {
     private String gender;
     private String address;
     private int phoneNumber;
+    private LocalDateTime uploadedAt;
 }

--- a/src/main/java/com/sharok/esquela/kafka/KafkaProducer.java
+++ b/src/main/java/com/sharok/esquela/kafka/KafkaProducer.java
@@ -1,6 +1,28 @@
 package com.sharok.esquela.kafka;
 
+import lombok.RequiredArgsConstructor;
+import lombok.SneakyThrows;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.clients.producer.RecordMetadata;
+import org.springframework.kafka.core.KafkaTemplate;
 import org.springframework.stereotype.Service;
 
 @Service
-public class KafkaProducer {}
+@Slf4j
+@RequiredArgsConstructor
+public class KafkaProducer {
+    private final KafkaTemplate<String, Object> kafkaTemplate;
+
+    @SneakyThrows
+    public void sendKafkaMessage(String topic, Object message) {
+        ProducerRecord<String, Object> record = new ProducerRecord<>(topic, message);
+        RecordMetadata metadata = kafkaTemplate.send(record).get().getRecordMetadata();
+        log.info("Message sent successfully to topic {} -> metadata {}", topic, metadata);
+        log.info(String.format("Message sent %s", message));
+    }
+
+    public void flush() {
+        kafkaTemplate.flush();
+    }
+}

--- a/src/main/java/com/sharok/esquela/kafka/StudentKafkaConsumer.java
+++ b/src/main/java/com/sharok/esquela/kafka/StudentKafkaConsumer.java
@@ -1,0 +1,18 @@
+package com.sharok.esquela.kafka;
+
+import com.sharok.esquela.contract.StudentMessage;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.stereotype.Service;
+
+@Service
+@Slf4j
+public class StudentKafkaConsumer {
+
+    @KafkaListener(
+            topics = "${spring.kafka.topic.student}",
+            groupId = "${spring.kafka.consumer.group-id}")
+    public void consume(StudentMessage message) {
+        log.info("Message received -> {}", message);
+    }
+}

--- a/src/main/java/com/sharok/esquela/kafka/StudentKafkaProducer.java
+++ b/src/main/java/com/sharok/esquela/kafka/StudentKafkaProducer.java
@@ -1,0 +1,29 @@
+package com.sharok.esquela.kafka;
+
+import com.sharok.esquela.contract.StudentMessage;
+import com.sharok.esquela.model.Student;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+public class StudentKafkaProducer extends KafkaProducer {
+    private final String studentTopic;
+
+    public StudentKafkaProducer(
+            KafkaTemplate<String, Object> kafkaTemplate,
+            @Value("${spring.kafka.topic.student}") String studentTopic) {
+        super(kafkaTemplate);
+        this.studentTopic = studentTopic;
+    }
+
+    public void produce(String messages, Student student) {
+        StudentMessage message =
+                new StudentMessage(messages, student.getId(), student.getUploadedAt());
+        log.info("Sending message to {}", studentTopic);
+        sendKafkaMessage(studentTopic, message);
+        log.info("Message published to {}", studentTopic);
+    }
+}

--- a/src/main/java/com/sharok/esquela/model/Student.java
+++ b/src/main/java/com/sharok/esquela/model/Student.java
@@ -1,14 +1,9 @@
 package com.sharok.esquela.model;
 
 import com.sharok.esquela.constant.Gender;
-import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import jakarta.persistence.*;
+import java.time.LocalDateTime;
+import lombok.*;
 
 @Entity
 @Getter
@@ -24,7 +19,11 @@ public class Student {
     private String middleName;
     private String lastName;
     private String dob;
+
+    @Enumerated(EnumType.STRING)
     private Gender gender;
+
     private String address;
     private int phoneNumber;
+    @Setter private LocalDateTime uploadedAt;
 }

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -1,22 +1,22 @@
 spring:
   datasource:
-    url: ${DB_URL}
-    username: ${DB_USERNAME}
-    password: ${DB_PASSWORD}
+    url: jdbc:postgresql://localhost:5432/esquela
+    username: postgres
+    password: edstem@23
     driver-class-name: org.postgresql.Driver
   kafka:
-    bootstrap-servers: ${KAFKA_BOOTSTRAP_SERVERS}
+    bootstrap-servers: localhost:9092
     producer:
       key-serializer: org.apache.kafka.common.serialization.StringSerializer
       value-serializer: org.springframework.kafka.support.serializer.JsonSerializer
     consumer:
-      group-id: ${KAFKA_GROUP_ID}
+      group-id: student-group
       key-deserializer: org.apache.kafka.common.serialization.StringDeserializer
       value-deserializer: org.springframework.kafka.support.serializer.JsonDeserializer
       properties:
         spring.json.trusted.packages: com.sharok.esquela.contract
     topic:
-      student: ${KAFKA_STUDENT_TOPIC}
+      student: student-events
   jpa:
     show-sql: true
     hibernate:

--- a/src/test/java/com/sharok/esquela/BaseControllerTests.java
+++ b/src/test/java/com/sharok/esquela/BaseControllerTests.java
@@ -1,0 +1,10 @@
+package com.sharok.esquela;
+
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+public class BaseControllerTests extends BaseKafkaTests {}

--- a/src/test/java/com/sharok/esquela/BaseKafkaTests.java
+++ b/src/test/java/com/sharok/esquela/BaseKafkaTests.java
@@ -1,0 +1,10 @@
+package com.sharok.esquela;
+
+import org.springframework.kafka.test.context.EmbeddedKafka;
+import org.springframework.test.annotation.DirtiesContext;
+
+@EmbeddedKafka(
+        topics = {"student-events-test"},
+        bootstrapServersProperty = "spring.kafka.bootstrap-servers")
+@DirtiesContext
+public class BaseKafkaTests {}

--- a/src/test/java/com/sharok/esquela/EsquelaApplicationTests.java
+++ b/src/test/java/com/sharok/esquela/EsquelaApplicationTests.java
@@ -1,10 +1,14 @@
 package com.sharok.esquela;
 
+import com.sharok.esquela.service.StudentService;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
 
 @SpringBootTest
-class EsquelaApplicationTests {
+class EsquelaApplicationTests extends BaseControllerTests {
+
+    @MockBean private StudentService userService;
 
     @Test
     void contextLoads() {}

--- a/src/test/java/com/sharok/esquela/controller/StudentControllerTest.java
+++ b/src/test/java/com/sharok/esquela/controller/StudentControllerTest.java
@@ -7,6 +7,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.sharok.esquela.BaseControllerTests;
 import com.sharok.esquela.contract.request.StudentRequest;
 import com.sharok.esquela.contract.response.StudentResponse;
 import com.sharok.esquela.exception.StudentNotFoundException;
@@ -14,15 +15,11 @@ import com.sharok.esquela.service.StudentService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
-import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 
-@SpringBootTest
-@AutoConfigureMockMvc
-public class StudentControllerTest {
+public class StudentControllerTest extends BaseControllerTests {
     @Autowired private MockMvc mockMvc;
     @MockBean private StudentService studentService;
     private StudentResponse expectedResponse;

--- a/src/test/java/com/sharok/esquela/kafka/StudentKafkaProducerTests.java
+++ b/src/test/java/com/sharok/esquela/kafka/StudentKafkaProducerTests.java
@@ -1,0 +1,88 @@
+package com.sharok.esquela.kafka;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.sharok.esquela.BaseKafkaTests;
+import com.sharok.esquela.model.Student;
+import com.sharok.esquela.service.StudentService;
+import java.time.Duration;
+import java.time.LocalDateTime;
+import java.util.Map;
+import org.apache.kafka.clients.consumer.Consumer;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.kafka.core.ConsumerFactory;
+import org.springframework.kafka.core.DefaultKafkaConsumerFactory;
+import org.springframework.kafka.test.EmbeddedKafkaBroker;
+import org.springframework.kafka.test.utils.KafkaTestUtils;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+@ExtendWith(SpringExtension.class)
+@SpringBootTest
+@ActiveProfiles("test")
+public class StudentKafkaProducerTests extends BaseKafkaTests {
+
+    @Autowired private StudentKafkaProducer studentKafkaProducer;
+
+    @Autowired private EmbeddedKafkaBroker embeddedKafka;
+
+    @MockBean private StudentService studentService;
+
+    @Test
+    public void testProduce() {
+        Student student =
+                Student.builder()
+                        .id(1L)
+                        .firstName("John")
+                        .lastName("Doe")
+                        .uploadedAt(LocalDateTime.now())
+                        .build();
+        String message = "Student data processed";
+
+        studentKafkaProducer.produce(message, student);
+
+        Map<String, Object> consumerProps =
+                KafkaTestUtils.consumerProps("studentTestGroup", "true", embeddedKafka);
+        consumerProps.put(
+                ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG,
+                org.apache.kafka.common.serialization.StringDeserializer.class);
+        consumerProps.put(
+                ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG,
+                org.apache.kafka.common.serialization.StringDeserializer.class);
+
+        ConsumerFactory<String, String> consumerFactory =
+                new DefaultKafkaConsumerFactory<>(consumerProps);
+        Consumer<String, String> consumer = consumerFactory.createConsumer();
+        embeddedKafka.consumeFromAnEmbeddedTopic(consumer, "student-events-test");
+
+        ConsumerRecord<String, String> record =
+                KafkaTestUtils.getSingleRecord(
+                        consumer, "student-events-test", Duration.ofSeconds(10));
+
+        assertNotNull(record, "Message not found in topic");
+        assertTrue(record.value().contains(student.getId().toString()));
+        assertTrue(record.value().contains(message));
+        consumer.close();
+    }
+
+    @Test
+    public void testProduceSerializationFailure() {
+        Student student = mock(Student.class);
+        when(student.getId()).thenThrow(new RuntimeException("Mocked exception"));
+        String message = "Student data failed";
+
+        RuntimeException exception =
+                assertThrows(
+                        RuntimeException.class,
+                        () -> studentKafkaProducer.produce(message, student));
+        assertEquals("Mocked exception", exception.getMessage());
+    }
+}

--- a/src/test/java/com/sharok/esquela/service/StudentServiceTest.java
+++ b/src/test/java/com/sharok/esquela/service/StudentServiceTest.java
@@ -9,6 +9,7 @@ import com.sharok.esquela.constant.Gender;
 import com.sharok.esquela.contract.request.StudentRequest;
 import com.sharok.esquela.contract.response.StudentResponse;
 import com.sharok.esquela.exception.StudentNotFoundException;
+import com.sharok.esquela.kafka.StudentKafkaProducer;
 import com.sharok.esquela.model.Student;
 import com.sharok.esquela.repository.StudentRepository;
 import java.util.Optional;
@@ -27,10 +28,11 @@ public class StudentServiceTest {
     private StudentRequest request;
     private StudentResponse expectedResponse;
     private Student student;
+    @Mock private StudentKafkaProducer studentKafkaProducer;
 
     @BeforeEach
     void setup() {
-        studentService = new StudentService(studentRepository, modelMapper);
+        studentService = new StudentService(studentRepository, modelMapper, studentKafkaProducer);
         request =
                 new StudentRequest(
                         "John", "Jacob", "Doe", "2012/01/02", "Male", "Kumily", 123456789);

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -1,23 +1,27 @@
 spring:
   datasource:
-    url: ${DB_URL}
-    username: ${DB_USERNAME}
-    password: ${DB_PASSWORD}
-    driver-class-name: org.postgresql.Driver
+    url: jdbc:h2:mem:testdb;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE
+    username: sa
+    password: password
+    driver-class-name: org.h2.Driver
   kafka:
-    bootstrap-servers: ${KAFKA_BOOTSTRAP_SERVERS}
+    bootstrap-servers: localhost:9092
     producer:
       key-serializer: org.apache.kafka.common.serialization.StringSerializer
       value-serializer: org.springframework.kafka.support.serializer.JsonSerializer
     consumer:
-      group-id: ${KAFKA_GROUP_ID}
+      group-id: student-group
       key-deserializer: org.apache.kafka.common.serialization.StringDeserializer
       value-deserializer: org.springframework.kafka.support.serializer.JsonDeserializer
       properties:
         spring.json.trusted.packages: com.sharok.esquela.contract
     topic:
-      student: ${KAFKA_STUDENT_TOPIC}
+      student: student-events-test
   jpa:
-    show-sql: true
+    database-platform: org.hibernate.dialect.H2Dialect
     hibernate:
-      ddl-auto: update
+      ddl-auto: create-drop
+    show-sql: true
+    properties:
+      hibernate:
+        format_sql: true


### PR DESCRIPTION
Kafka Integration for Student Service
This implementation leverages Kafka to asynchronously handle student-related operations such as adding, updating, and deleting students, while sending relevant messages to Kafka topics.

Kafka Producer (StudentKafkaProducer)
The StudentKafkaProducer is responsible for producing messages to Kafka. It sends a StudentMessage (containing student details) to a configured Kafka topic. This producer class is built on top of the generic KafkaProducer service, which provides the core functionality of sending messages.

The produce() method in StudentKafkaProducer prepares a StudentMessage with the message and relevant student data, then sends the message to the Kafka topic specified in the configuration.
The sendKafkaMessage() method in the base KafkaProducer service uses KafkaTemplate to send the message to the Kafka broker, and logs the metadata when the message is successfully sent.
Kafka Consumer (StudentKafkaConsumer)
The StudentKafkaConsumer listens to the Kafka topic defined in the application properties. It uses the @KafkaListener annotation to consume messages from the Kafka topic (which is configured to receive student-related events).

The consume() method processes the consumed message (here, it's a StudentMessage) and logs the message details.
Student Service (StudentService)
The StudentService is responsible for managing the CRUD operations on student data and orchestrating the message flow to Kafka.

When a new student is added, the service saves the student to the database and then triggers the StudentKafkaProducer to send a "Student added" message to Kafka.
Similarly, when a student is updated or deleted, the corresponding action is followed by sending an appropriate Kafka message ("Student updated" or "Student deleted").
Flow
Add Student:

The service creates a new Student record in the database.
After saving, it sends a "Student added" message to the Kafka topic using StudentKafkaProducer.
Update Student:

The service updates the student data in the database.
After the update, it sends a "Student updated" message to the Kafka topic.
Delete Student:

The service deletes a student from the database.
After deletion, it sends a "Student deleted" message to the Kafka topic.
Configuration
Producer Configuration: Configures Kafka properties, such as key-serializer and value-serializer, and specifies the topic to which messages will be sent.
Consumer Configuration: The consumer listens for messages from the specified Kafka topic, processes the messages, and logs the received data.